### PR TITLE
Fix code-cells-forward-cell for repeated invocations

### DIFF
--- a/code-cells.el
+++ b/code-cells.el
@@ -94,7 +94,8 @@ backward."
   (let ((page-delimiter (code-cells-boundary-regexp)))
     (forward-page arg)
     (unless (eobp)
-      (move-beginning-of-line 1))))
+      (move-beginning-of-line 1)
+      (forward-char))))
 
 ;;;###autoload
 (defun code-cells-backward-cell (&optional arg)


### PR DESCRIPTION
When point is at the page delimiter, `forward-page`
just skips to the end of it.
But `code-cells-forward-cell` then "resets" the pointer
to the beginning of line which makes it impossible
to call `code-cells-forward-cell` multiple times in a row.